### PR TITLE
VSTS-10935 - Background Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,37 @@
 Role Name
 =========
 
-A brief description of the role goes here.
+Adds systemd configuration for a [Shoryuken](https://github.com/phstc/shoryuken) worker process deployed with Capistrano 3 on Ubuntu 16.04.
 
 Requirements
 ------------
 
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+A functioning Rails deployment using Capistrano 3 on Ubuntu 16.04 is required to use this role.
 
 Role Variables
 --------------
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+**ansible_systemd_shoryuken_user**: The owner of the Shoryuken process.
+**ansible_systemd_shoryuken_app_path**: The full path to the Capistrano 3 deployment directory.
 
-Dependencies
-------------
-
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
 
 Example Playbook
 ----------------
 
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
-
-    - hosts: servers
-      roles:
-         - { role: username.rolename, x: 42 }
+```yaml
+- hosts: servers
+  roles:
+     - role: amaabca.ansible-systemd-shoryuken
+       ansible_systemd_shoryuken_user: appserver
+       ansible_systemd_shoryuken_app_path: /srv/myapp
+```
 
 License
 -------
 
-BSD
+MIT
 
 Author Information
 ------------------
 
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).
+https://github.com/amaabca/ansible-systemd-shoryuken

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
-# defaults file for ansible-systemd-shoryuken
+ansible_systemd_shoryuken_app_path: '/srv/{{ app_name }}'
+ansible_systemd_shoryuken_user: '{{ deployer }}'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,57 +1,15 @@
 galaxy_info:
-  author: your name
-  description: your description
-  company: your company (optional)
-
-  # If the issue tracker for your role is not on github, uncomment the
-  # next line and provide a value
-  # issue_tracker_url: http://example.com/issue/tracker
-
-  # Some suggested licenses:
-  # - BSD (default)
-  # - MIT
-  # - GPLv2
-  # - GPLv3
-  # - Apache
-  # - CC-BY
-  license: license (GPLv2, CC-BY, etc)
-
-  min_ansible_version: 1.2
-
-  # If this a Container Enabled role, provide the minimum Ansible Container version.
-  # min_ansible_container_version:
-
-  # Optionally specify the branch Galaxy will use when accessing the GitHub
-  # repo for this role. During role install, if no tags are available,
-  # Galaxy will use this branch. During import Galaxy will access files on
-  # this branch. If Travis integration is configured, only notifications for this
-  # branch will be accepted. Otherwise, in all cases, the repo's default branch
-  # (usually master) will be used.
-  #github_branch:
-
-  #
-  # platforms is a list of platforms, and each platform has a name and a list of versions.
-  #
-  # platforms:
-  # - name: Fedora
-  #   versions:
-  #   - all
-  #   - 25
-  # - name: SomePlatform
-  #   versions:
-  #   - all
-  #   - 1.0
-  #   - 7
-  #   - 99.99
-
-  galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
-
+  author: Alberta Motor Association
+  description: Add shoryuken as a systemd-managed service on Ubuntu.
+  company: Alberta Motor Association
+  license: MIT
+  min_ansible_version: 2.0
+  platforms:
+    - name: Ubuntu
+      versions:
+        - xenial
+  galaxy_tags:
+    - systemd
+    - shoryuken
+    - ubuntu
 dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,14 @@
 ---
-# tasks file for ansible-systemd-shoryuken
+- name: Skoryuken | Service Template
+  template:
+    src: shoryuken.service
+    dest: /lib/systemd/system/shoryuken.service
+    owner: root
+    group: root
+  become: yes
+- name: Shoryuken | Enable Process
+  systemd:
+    daemon_reload: yes
+    enabled: yes
+    name: shoryuken
+    state: started

--- a/templates/shoryuken.service
+++ b/templates/shoryuken.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=shoryuken
+After=syslog.target network.target
+
+[Service]
+Type=simple
+SyslogIdentifier=shoryuken
+User={{ ansible_systemd_shoryuken_user }}
+WorkingDirectory={{ ansible_systemd_shoryuken_app_path }}/current
+EnvironmentFile={{ ansible_systemd_shoryuken_app_path }}/current/.env
+PIDFile={{ ansible_systemd_shoryuken_app_path }}/shared/tmp/pids/shoryuken.pid
+ExecStart={{ ansible_systemd_shoryuken_app_path }}/current/bin/bundle exec shoryuken start --pidfile {{ ansible_systemd_shoryuken_app_path }}/shared/tmp/pids/shoryuken.pid --logfile {{ ansible_systemd_shoryuken_app_path }}/shared/log/shoryuken.log --config config/shoryuken.yml --rails
+ExecStop=/bin/kill --signal USR1 $MAINPID
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
:elephant:

* Enable systemd as a process monitor for our Shoryuken background
  worker processes. We need to ensure that systemd starts the
  the workers when the server is rebooted or if a process crashes.
* Don't start the Shoryuken process using the `daemon` mode so that
  systemd is able to properly daemonize the process itself. See
  http://0pointer.de/public/systemd-man/daemon.html#New-Style%20Daemons.
* Configure systemd to start the process with the proper environment
  variables by specifying the EnvironmentFile directive.

SEE: https://amaabca.visualstudio.com/driver_education_backlog/_workitems/edit/10935